### PR TITLE
Fix bug in out-of-bounds-checker

### DIFF
--- a/Tic_tac_toe.py
+++ b/Tic_tac_toe.py
@@ -57,7 +57,7 @@ class Board:
         """Returns True if the position is valid (i.e. is not out of bounds of the board).
         Returns False otherwise
         """
-        return 0 <= position < len(board)
+        return 0 < position <= len(board)
 
       
 class Player:


### PR DESCRIPTION
The logic for checking an out-of-bounds position is now fixed. 
Previously position `0` was valid, while `9` was invalid. 
Now, position `0` is invalid, while position `9` is valid.

- previously
```sh
$ python3 Tic_tac_toe.py

   |   |
_________

   |   |
_________

   |   |
Current player: O
Enter the position: 0

   |   |
_________

   |   |
_________

   |   | O
Current player: X
Enter the position:
```
- now
```sh
$ python3 Tic_tac_toe.py 

   |   |
_________

   |   |
_________

   |   |
Current player: O   
Enter the position: 0
Position is invalid!! Choose another position 

Current player: O
Enter the position: 9

   |   |
_________

   |   |
_________

   |   | O
Current player: X   
Enter the position: 
```